### PR TITLE
Add Dockerfile for arm32v7

### DIFF
--- a/content/dotnet-template-azure-iot-edge-function/CSharp/module.json
+++ b/content/dotnet-template-azure-iot-edge-function/CSharp/module.json
@@ -8,6 +8,7 @@
             "platforms": {
                 "amd64": "./Dockerfile", 
                 "amd64.debug": "./Dockerfile.amd64.debug",
+                "arm32v7": "./Dockerfile",
                 "windows-amd64": "./Dockerfile"
             }
         },


### PR DESCRIPTION
[Remote debugging on ARM](https://github.com/OmniSharp/omnisharp-vscode/wiki/Remote-Debugging-On-Linux-Arm) is still a beta feature and relies on .NET Core 2.1 preview. I will investigate integrating it after it graduates from beta status.