### PR TITLE
Update SampleFunction with Dispose pattern

### DIFF
--- a/content/dotnet-template-azure-iot-edge-function/CSharp/SampleFunction.cs
+++ b/content/dotnet-template-azure-iot-edge-function/CSharp/SampleFunction.cs
@@ -26,13 +26,15 @@ namespace Functions.Samples
             if (!string.IsNullOrEmpty(messageString))
             {
                 logger.LogInformation("Info: Received one non-empty message");
-                var pipeMessage = new Message(messageBytes);
-                foreach (KeyValuePair<string, string> prop in messageReceived.Properties)
+                using (var pipeMessage = new Message(messageBytes))
                 {
-                    pipeMessage.Properties.Add(prop.Key, prop.Value);
+                    foreach (KeyValuePair<string, string> prop in messageReceived.Properties)
+                    {
+                        pipeMessage.Properties.Add(prop.Key, prop.Value);
+                    }
+                    await output.AddAsync(pipeMessage);
+                    logger.LogInformation("Info: Piped out the message");
                 }
-                await output.AddAsync(pipeMessage);
-                logger.LogInformation("Info: Piped out the message");
             }
         }
     }


### PR DESCRIPTION
As discussed in https://github.com/microsoft/vscode-azure-iot-edge/issues/503

In the C# module template and the C# function template, a message is constructed:

var pipeMessage = new Message(messageBytes);

The Message class implements the Dispose method. The Message class must follow the Dispose pattern to ensure it's disposed in all paths.

With 'using()' we can enforce the Dispose pattern.

This is also in sync with eg. the https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-csharp-module documentation.